### PR TITLE
fix for discovery document upload timeout failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,53 @@ cd assistant-with-discovery-openwhisk
 npm install
 ```
 
+**Note**:  
+If you receive the following error during `npm install`:
+```
+gyp ERR! stack Error: Python executable "python" is v3.4.3, which is not supported by gyp.
+gyp ERR! stack You can pass the --python switch to point to Python >= v2.5.0 & < 3.0.0.
+```
+Install Python 2.7.x and set npm to use. e.g.  
+```npm config set python /path/to/python```  
+
 ### Setting up Watson Services
 > Skip this section if you have downloaded the project from [Watson Console](https://console.ng.bluemix.net/developer/watson) and already have a `credentials.json` file
 
+> If you don't have any instances of Watson Assistant or Watson Discovery
 1. [Create  a project](https://console.bluemix.net/developer/watson/create-project?services=conversation%2Cdiscovery) using the Watson Console using Watson Assistant and Discovery services.
 
 2. In the Watson Console navigate to [Projects](https://console.bluemix.net/developer/watson/projects), click your newly created project, copy credentials from Project View page and paste them in to a new `credentials.json` file.
+
+> If you have instances of Watson Assistant and Watson Discovery that you wish to re-use
+1. Create a `credentials.json` in the top-level directory.
+
+2. Copy the following credentials into the file, amending for the instance name, url, username, and password; which can be found on each instance in the IBM Cloud console
+```
+{
+  "discovery": [
+    {
+      "name": "Discovery-inst",
+      "plan": "lite",
+      "credentials": {
+        "url": "https://gateway.watsonplatform.net/discovery/api",
+        "username": "enterUserName",
+        "password": "enterPassword"
+      }
+    }
+  ],
+  "conversation": [
+    {
+      "name": "Assistant-inst",
+      "plan": "free",
+      "credentials": {
+        "url": "https://gateway.watsonplatform.net/assistant/api",
+        "username": "enterUserName",
+        "password": "enterPassword"
+      }
+    }
+  ]
+}
+```
 
 ### Train Watson Services
 Run following commands to train Watson Assistant and Discovery services:
@@ -70,6 +111,7 @@ Run following commands to train Watson Assistant and Discovery services:
 
 ```bash
 bx login
+bx target --cf
 ```
 
 4. Install [jq](https://stedolan.github.io/jq/download/) as a dependency.
@@ -92,5 +134,17 @@ All that's left is to serve your static files locally. You should see the projec
 npm start
 ```
 
+Example commands that can be executed by the Watson Assistant service are:
+```
+turn on windshield wipers
+play music
+```
+In addition to conversational commands, you can also ask questions that you would expect to have answered in your car manual. For example:
+```
+How do I check my tire pressure
+How do I turn on cruise control
+How do I improve fuel efficiency
+How do I connect my phone to bluetooth
+```
 ## License
 Licensed under [Apache 2.0](LICENSE).

--- a/train-discovery.js
+++ b/train-discovery.js
@@ -12,7 +12,7 @@ var path = require('path');
 
 process.env.VCAP_SERVICES = process.env.VCAP_SERVICES || fs.readFileSync('./credentials.json', 'utf-8');
 
-var apiVersionDate = "2018-03-05"
+var apiVersionDate = '2018-03-05';
 var discoveryV1 = new DiscoveryV1({ version: 'v1', version_date: apiVersionDate });
 var retryOptions = { times: 3, interval: 200 };
 var defaultConfigName = 'Default Configuration with NLU'; // Use default configuration

--- a/train-discovery.js
+++ b/train-discovery.js
@@ -12,9 +12,10 @@ var path = require('path');
 
 process.env.VCAP_SERVICES = process.env.VCAP_SERVICES || fs.readFileSync('./credentials.json', 'utf-8');
 
-var discoveryV1 = new DiscoveryV1({ version: 'v1', version_date: '2017-04-27' });
+var apiVersionDate = "2018-03-05"
+var discoveryV1 = new DiscoveryV1({ version: 'v1', version_date: apiVersionDate });
 var retryOptions = { times: 3, interval: 200 };
-var defaultConfigName = 'Default Configuration'; // Use default configuration
+var defaultConfigName = 'Default Configuration with NLU'; // Use default configuration
 var collectionName = 'demoCollection';
 var collectionDescription = 'Collection for Watson Assistant with Discovery - OpenWhisk';
 var environmentName = 'demoEnvironment';
@@ -112,7 +113,7 @@ var createCollectionAsync = function(params, cb) {
     name: collectionName,
     description: collectionDescription,
     configuration_id: `${params.config_id}`,
-    version: '2017-04-27'
+    version: apiVersionDate
   }), cb);
 };
 


### PR DESCRIPTION
## Problem Description
When a user executes `npm run train`, during the document upload phase, they will see the following error:
```
manualdocs/manual_0.json { Error: Callback function "uploadDocumentAsync" timed out.
    at Timeout.timeoutCallback [as _onTimeout] (/**/*/WatsonAssistantWithDiscoveryOpenWhisk/node_modules/async/dist/async.js:4916:26)
    at ontimeout (timers.js:458:11)
    at tryOnTimeout (timers.js:296:5)
    at Timer.listOnTimeout (timers.js:259:5) code: 'ETIMEDOUT' }
```
(see issue #43).

## Solution
The default configuration file that was used when creating the Discovery collection was configured to use the [older AlchemyLanguage enrichments](https://console.bluemix.net/docs/services/discovery/migrate-nlu.html#migrating-enrichments-to-natural-language-understanding). As of the migration, when anyone attempted to upload documents, they would receive the above error.

The default configuration file used during the `train-discovery.js` script was changed to use the NLU enrichment technology.